### PR TITLE
Improve input validation and error handling

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,22 +1,41 @@
 """Minimal Flask dashboard for uploading receipts and viewing costs."""
-from flask import Flask, render_template, request, redirect, url_for
+import os
 from pathlib import Path
 
+from flask import Flask, render_template, request, redirect, url_for
+from werkzeug.utils import secure_filename
+
 app = Flask(__name__)
-UPLOAD_DIR = Path('uploads')
+UPLOAD_DIR = Path("uploads")
 UPLOAD_DIR.mkdir(exist_ok=True)
+ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg", "pdf"}
 
-@app.route('/')
+
+def _allowed_file(filename: str) -> bool:
+    """Check if the uploaded file has an allowed extension."""
+    return "." in filename and filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
+
+
+@app.route("/")
 def index():
-    files = [f.name for f in UPLOAD_DIR.glob('*')]
-    return render_template('index.html', files=files)
+    files = [f.name for f in UPLOAD_DIR.glob("*")]
+    return render_template("index.html", files=files)
 
-@app.route('/upload', methods=['POST'])
+
+@app.route("/upload", methods=["POST"])
 def upload():
-    file = request.files['receipt']
-    dest = UPLOAD_DIR / file.filename
-    file.save(dest)
-    return redirect(url_for('index'))
+    file = request.files.get("receipt")
+    if not file or file.filename == "":
+        return redirect(url_for("index"))
 
-if __name__ == '__main__':
-    app.run(debug=True)
+    filename = secure_filename(file.filename)
+    if not _allowed_file(filename):
+        return "Unsupported file type", 400
+
+    dest = UPLOAD_DIR / filename
+    file.save(dest)
+    return redirect(url_for("index"))
+
+
+if __name__ == "__main__":
+    app.run(debug=os.environ.get("FLASK_DEBUG") == "1")

--- a/src/ocr/job_assigner.py
+++ b/src/ocr/job_assigner.py
@@ -2,17 +2,22 @@
 import csv
 from pathlib import Path
 
+
 def assign_jobs(csv_path: str):
-    rows = list(csv.DictReader(open(csv_path)))
+    """Interactively tag each line item with a job ID."""
+    with open(csv_path, newline="") as f:
+        rows = list(csv.DictReader(f))
+
     for row in rows:
         print(f"Item: {row.get('item')} | Cost: {row.get('price')}")
-        row['job_id'] = input('Enter job ID: ')
-    out_path = Path(csv_path).with_name(Path(csv_path).stem + '_tagged.csv')
-    with open(out_path, 'w', newline='') as f:
+        row["job_id"] = input("Enter job ID: ")
+
+    out_path = Path(csv_path).with_name(Path(csv_path).stem + "_tagged.csv")
+    with open(out_path, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=rows[0].keys())
         writer.writeheader()
         writer.writerows(rows)
-    print(f'Saved tagged file to {out_path}')
+    print(f"Saved tagged file to {out_path}")
 
 if __name__ == '__main__':
     import sys

--- a/src/ocr/receipt_ocr.py
+++ b/src/ocr/receipt_ocr.py
@@ -8,9 +8,15 @@ import json
 from PIL import Image
 import pytesseract
 
+
 def extract_receipt(image_path: str) -> dict:
-    """Extract text from receipt image and return basic structured data."""
-    text = pytesseract.image_to_string(Image.open(image_path))
+    """Extract text from a receipt image and return structured data."""
+    try:
+        with Image.open(image_path) as img:
+            text = pytesseract.image_to_string(img)
+    except (OSError, FileNotFoundError) as exc:
+        return {"error": str(exc)}
+
     # Placeholder parsing logic; would parse line items here
     return {"raw_text": text}
 
@@ -18,7 +24,7 @@ def extract_receipt(image_path: str) -> dict:
 def main(paths):
     for img in paths:
         data = extract_receipt(img)
-        out_path = Path(img).with_suffix('.json')
+        out_path = Path(img).with_suffix(".json")
         out_path.write_text(json.dumps(data, indent=2))
         print(f"Written {out_path}")
 


### PR DESCRIPTION
## Summary
- Sanitize uploaded filenames and restrict allowed file types in Flask dashboard
- Use context managers for CSV handling in job assigner CLI
- Add error handling around image OCR to avoid crashes

## Testing
- `python -m py_compile src/ocr/receipt_ocr.py src/ocr/job_assigner.py src/dashboard/app.py`
- `bandit -r src` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b53b472fec8321ac3be4e8d9b18f6b