### PR TITLE
Expose Flask on all interfaces

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -38,4 +38,7 @@ def upload():
 
 
 if __name__ == "__main__":
-    app.run(debug=os.environ.get("FLASK_DEBUG") == "1")
+    app.run(
+        host="0.0.0.0",
+        debug=os.environ.get("FLASK_DEBUG") == "1",
+    )


### PR DESCRIPTION
## Summary
- Run Flask app on all network interfaces for container access

## Testing
- `python -m pytest`
- `docker build -t rudy-automation .` (command failed: command not found: docker)
- `docker run -p 5000:5000 rudy-automation` (command failed: command not found: docker)


------
https://chatgpt.com/codex/tasks/task_e_68b540f95a908321915b6d0210ba29ef