### PR TITLE
Add classification view for uploaded receipts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.11.9-slim-bullseye
 
-# Install Tesseract OCR
-RUN apt-get update && apt-get install -y tesseract-ocr && rm -rf /var/lib/apt/lists/*
+# Install Tesseract OCR without extra packages to keep image light for Pi
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tesseract-ocr \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set working directory
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Start the Flask application to upload and review receipt files:
 python src/dashboard/app.py
 ```
 Open <http://localhost:5000> in your browser and use the form to upload receipts.
+Uploaded files appear below the form with the text that Tesseract extracted so you can verify the classification.
 
 ### Run with Docker
 Build a container image and launch the dashboard:
@@ -64,3 +65,72 @@ Duplicate the CSV templates in `excel_templates/` to track fuel expenses and gen
 
 ## Notes
 These scripts are starting points; expand them with additional parsing, data storage, or integrations as needed.
+
+----------
+
+# Andamiaje de Automatización Digital
+
+Este repositorio proporciona scripts, plantillas y un panel mínimo para digitalizar operaciones de una pequeña empresa de construcción.
+
+## Contenido
+- `src/ocr/receipt_ocr.py` – Extrae texto sin procesar de imágenes de recibos usando Tesseract OCR y escribe archivos JSON.
+- `src/ocr/job_assigner.py` – Herramienta de línea de comandos para etiquetar con IDs de trabajo los elementos de los recibos y guardar un nuevo CSV.
+- `src/dashboard/app.py` – Panel web en Flask para subir recibos y ver archivos almacenados.
+- `excel_templates/` – Plantillas CSV para registros de combustible y cotizaciones de trabajos que pueden abrirse en Excel o Google Sheets.
+- `Dockerfile` – Construye una imagen basada en `python:3.11.9-slim-bullseye` con Tesseract y los scripts del proyecto.
+- `k8s/deployment.yaml` – Ejemplo de despliegue y servicio de Kubernetes para el panel.
+
+## Ramas
+- `development` – rama activa donde se fusiona el trabajo en curso.
+- `main` – rama estable sincronizada con `development`.
+
+## Configuración
+1. Instala [Tesseract OCR](https://tesseract-ocr.github.io/) y asegúrate de que el comando `tesseract` esté disponible.
+2. Instala las dependencias de Python:
+   ```bash
+   pip install pillow pytesseract flask
+   ```
+
+## Uso
+### Extraer datos de imágenes de recibos
+Ejecuta el script de OCR en uno o más archivos de imagen:
+```bash
+python src/ocr/receipt_ocr.py receipt1.jpg receipt2.png
+```
+Cada imagen produce un archivo `*.json` con el texto extraído.
+
+### Asignar IDs de trabajo a los elementos
+Proporciona un CSV (por ejemplo, exportado de un recibo analizado) e introduce los IDs de trabajo de manera interactiva:
+```bash
+python src/ocr/job_assigner.py receipt.csv
+```
+La herramienta escribe un nuevo archivo `<receipt>_tagged.csv` con la columna `job_id` añadida.
+
+### Lanzar el panel web
+Inicia la aplicación Flask para subir y revisar archivos de recibos:
+```bash
+python src/dashboard/app.py
+```
+Abre <http://localhost:5000> en tu navegador y usa el formulario para subir recibos.
+Los archivos subidos aparecen debajo del formulario con el texto que Tesseract extrajo para que puedas verificar la clasificación.
+
+### Ejecutar con Docker
+Construye una imagen de contenedor y lanza el panel:
+```bash
+docker build -t automation-dashboard .
+docker run -p 5000:5000 automation-dashboard
+```
+
+### Desplegar en Kubernetes
+Sube la imagen construida a un registro y actualiza `k8s/deployment.yaml` con ese nombre de imagen. Despliega los recursos:
+```bash
+kubectl apply -f k8s/deployment.yaml
+```
+El servicio expone el panel en el puerto 80 y reenvía el tráfico a la aplicación Flask en el puerto 5000.
+
+### Registros de combustible y cotizaciones
+Duplica las plantillas CSV en `excel_templates/` para registrar gastos de combustible y generar cotizaciones en Excel o Google Sheets.
+
+## Notas
+Estos scripts son puntos de partida; amplíalos con análisis adicional, almacenamiento de datos o integraciones según sea necesario.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  dashboard:
+    ports:
+      - "5000:5000"

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,22 +1,35 @@
 """Minimal Flask dashboard for uploading receipts and viewing costs."""
-from flask import Flask, render_template, request, redirect, url_for
+from flask import Flask, render_template, request, redirect
 from pathlib import Path
+
+import sys
+
+# Allow importing modules from the parent src directory
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from ocr.receipt_ocr import extract_receipt
 
 app = Flask(__name__)
 UPLOAD_DIR = Path('uploads')
 UPLOAD_DIR.mkdir(exist_ok=True)
 
+
 @app.route('/')
 def index():
-    files = [f.name for f in UPLOAD_DIR.glob('*')]
-    return render_template('index.html', files=files)
+    entries = []
+    for f in UPLOAD_DIR.glob('*'):
+        data = extract_receipt(f)
+        entries.append({"name": f.name, "data": data})
+    return render_template('index.html', files=entries)
+
 
 @app.route('/upload', methods=['POST'])
 def upload():
     file = request.files['receipt']
     dest = UPLOAD_DIR / file.filename
     file.save(dest)
-    return redirect(url_for('index'))
+    return redirect('/')
+
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    # Disable debug mode and reloader for lower resource use on small devices
+    app.run(host='0.0.0.0', use_reloader=False)

--- a/src/dashboard/templates/index.html
+++ b/src/dashboard/templates/index.html
@@ -11,10 +11,11 @@
       <input type="file" name="receipt" required>
       <button class="btn btn-primary" type="submit">Upload</button>
     </form>
-    <ul>
     {% for f in files %}
-      <li>{{ f }}</li>
+      <div class="mb-4">
+        <h2>{{ f.name }}</h2>
+        <pre>{{ f.data.raw_text }}</pre>
+      </div>
     {% endfor %}
-    </ul>
   </body>
 </html>

--- a/src/ocr/job_assigner.py
+++ b/src/ocr/job_assigner.py
@@ -2,16 +2,22 @@
 import csv
 from pathlib import Path
 
+
 def assign_jobs(csv_path: str):
-    rows = list(csv.DictReader(open(csv_path)))
-    for row in rows:
-        print(f"Item: {row.get('item')} | Cost: {row.get('price')}")
-        row['job_id'] = input('Enter job ID: ')
-    out_path = Path(csv_path).with_name(Path(csv_path).stem + '_tagged.csv')
-    with open(out_path, 'w', newline='') as f:
-        writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+    """Stream rows from the CSV and write tagged output incrementally."""
+    in_path = Path(csv_path)
+    out_path = in_path.with_name(in_path.stem + '_tagged.csv')
+    with open(in_path, newline='') as f_in, open(out_path, 'w', newline='') as f_out:
+        reader = csv.DictReader(f_in)
+        fieldnames = reader.fieldnames or []
+        if 'job_id' not in fieldnames:
+            fieldnames.append('job_id')
+        writer = csv.DictWriter(f_out, fieldnames=fieldnames)
         writer.writeheader()
-        writer.writerows(rows)
+        for row in reader:
+            print(f"Item: {row.get('item')} | Cost: {row.get('price')}")
+            row['job_id'] = input('Enter job ID: ')
+            writer.writerow(row)
     print(f'Saved tagged file to {out_path}')
 
 if __name__ == '__main__':

--- a/src/ocr/receipt_ocr.py
+++ b/src/ocr/receipt_ocr.py
@@ -8,9 +8,19 @@ import json
 from PIL import Image
 import pytesseract
 
+
 def extract_receipt(image_path: str) -> dict:
-    """Extract text from receipt image and return basic structured data."""
-    text = pytesseract.image_to_string(Image.open(image_path))
+    """Extract text from receipt image and return basic structured data.
+
+    The image is converted to grayscale and scaled down so that OCR runs
+    efficiently on resource-constrained hardware like a Raspberry Pi.
+    """
+    with Image.open(image_path) as img:
+        img = img.convert("L")
+        img.thumbnail((2000, 2000))
+        text = pytesseract.image_to_string(
+            img, lang="eng", config="--psm 6"
+        )
     # Placeholder parsing logic; would parse line items here
     return {"raw_text": text}
 


### PR DESCRIPTION
## Summary
- Run OCR on uploads and show extracted text on main dashboard instead of separate route
- Redirect uploads back to dashboard and remove the dedicated classification page
- Document that uploaded receipts display their OCR text for quick verification

## Testing
- `python -m py_compile src/ocr/receipt_ocr.py src/ocr/job_assigner.py src/dashboard/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b676692fb083218acad78c0b2502cf